### PR TITLE
Added more input options.

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -15,6 +15,54 @@
       "class": "array:file",
       "patterns": ["*.fastq.gz", "*.fq.gz"],
       "optional": false
+    },
+    {
+      "name": "contaminants_txt",
+      "label": "Custom contaminants",
+      "help": "(Optional) A special file containing custom contaminant sequences to screen overrepresented sequences against. If left empty, a default set of contaminants that comes with the FastQC package will be used. If provided, this file must be a text file with two tab-delimited columns: name (such as 'Truseq Adapter') and DNA sequence (such as 'TATCTCGTATG').",
+      "class": "file",
+      "patterns": ["*.fastqc_contaminants.txt"],
+      "optional": true
+    },
+    {
+      "name": "adapters_txt",
+      "label": "Custom adapters",
+      "help": "(Optional) A special file containing custom adapter sequences which will be explicity searched against the library. If left empty, a default set of adapters that comes with the FastQC package will be used. If provided, this file must be a text file with two tab-delimited columns: name (such as 'Nextera Transposase Sequence') and DNA sequence (such as 'CTGTCTCTTATA').",
+      "class": "file",
+      "patterns": ["*.fastqc_adapters.txt"],
+      "optional": true
+    },
+    {
+      "name": "limits_txt",
+      "label": "Custom limits",
+      "help": "(Optional) A special file containing a set of criteria which will be used to determine the warn/error limits for the various modules, or selectively remove some modules from the output altogether. For an example of a limits file, refer to the limits.txt file in the FastQC sources.",
+      "class": "file",
+      "patterns": ["*.fastqc_limits.txt"],
+      "optional": true
+    },
+    {
+      "name": "kmer_size",
+      "label": "Kmer size",
+      "help": "The kmer size that the kmer analysis module will use. This module reports overrepresented k-mers (sequences of size 'k'). This size must be between 2 and 10 (default is 7).",
+      "class": "int",
+      "default": 7,
+      "group": "Advanced"
+    },
+    {
+      "name": "nogroup",
+      "label": "Disable grouping of bases past 50bp?",
+      "help": "Disable grouping of bases for reads >50bp. All reports will show data for every base in the read. WARNING: Using this option may cause fastqc to slow down or crash if used on really long reads, and resulting plots may be too large for practical viewing.",
+      "class": "boolean",
+      "default": true,
+      "group": "Advanced"
+    },
+    {
+      "name": "extra_options",
+      "label": "Extra command-line options",
+      "help": "(Optional) Extra command-line options that will be passed directly to the fastqc invocation. Example: --nofilter.",
+      "class": "string",
+      "optional": true,
+      "group": "Advanced"
     }
   ],
   "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,11 +1,11 @@
 {
-  "name": "multi_fastqc_v1.0.0",
-  "title": "multi_fastqc_v1.0.0",
+  "name": "multi_fastqc_v1.1.0",
+  "title": "multi_fastqc_v1.1.0",
   "summary": "Runs fastqc once for each input fastq",
   "dxapi": "1.0.0",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "properties": {
-    "githubRelease": "v1.0.0"
+    "githubRelease": "v1.1.0"
   },
   "inputSpec": [
     {

--- a/src/code.sh
+++ b/src/code.sh
@@ -40,7 +40,6 @@ dx cat "$reads" | zcat | /FastQC/fastqc --extract -t $(nproc) -k "${kmer_size}" 
 #
 # Upload results
 #
-#mark-section "uploading results"
 
 mkdir -p ~/out/report_html/ ~/out/stats_txt/
 mv results/*/fastqc_report.html ~/out/report_html/"$reads_prefix".stats-fastqc.html
@@ -51,8 +50,6 @@ dx-jobutil-add-output report_html "${report_html}" --class=file
 
 stats_txt=$(dx upload /home/dnanexus/out/stats_txt/${reads_prefix}.stats-fastqc.txt --brief)
 dx-jobutil-add-output stats_txt "${stats_txt}" --class=file
-
-#mark-success
 
 }
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -21,38 +21,6 @@ fastqc() {
 # and to output each line as it is executed -- useful for debugging
 set -e -x -o pipefail
 
-#
-# Set up some options
-#
-opts=()
-if [[ "${contaminants_txt}" != "" ]]; then
-    opts+=("-c" "./in/contaminants_txt/*")
-fi
-if [[ "${adapters_txt}" != "" ]]; then
-    opts+=("-a" "./in/adapters_txt/*")
-fi
-if [[ "${limits_txt}" != "" ]]; then
-    opts+=("-l" "./in/limits_txt/*")
-fi
-if [[ "${format}" != "auto" ]]; then
-    opts+=("-f" "${format}")
-else
-    file_extension="${reads_name##*.}"
-    if [[ "${file_extension}" == "bam" ]]; then
-        sample_name=${reads_name}
-        format="bam"
-    elif [[ "${file_extension}" == "sam" ]]; then
-        sample_name=${reads_name}
-        format="sam"
-    else
-        sample_name=${reads_prefix}
-        format="fastq"
-    fi
-    opts+=("-f" "${format}")
-fi
-if [[ "${nogroup}" == "true" ]]; then
-    opts+=("--nogroup")
-fi
 # Run FastQC
 
 sample_name=${reads_name%.fastq.gz}
@@ -63,22 +31,17 @@ sample_name=${sample_name%.sam}
 mkdir results
 
 # FASTQC doesn't play nicely with streamed BAM/SAM inputs
-# Using non-streaming method of downloading for BAM/SAM
-if [[ "${format}" == "bam" || "${format}" == "sam" ]]; then
-    #mark-section "downloading input file"
-    dx download "$reads"
-    #mark-section "running FastQC"
-    /FastQC/fastqc -t $(nproc) --extract -k "${kmer_size}" -o results "${opts[@]}" $extra_options ./"$reads_name"
+
 # Using streaming method of downloading for FASTQ/FASTQ.gz inputs
-else
-    #mark-section "running FastQC"
-    dx cat "$reads" | zcat | /FastQC/fastqc --extract -t $(nproc) -k "${kmer_size}" -o results "${opts[@]}" $extra_options stdin:"$sample_name"
-fi
+#mark-section "running FastQC"
+
+dx cat "$reads" | zcat | /FastQC/fastqc --extract -t $(nproc) -k "${kmer_size}" -o results ${opts} -f "fastq" ${extra_options} stdin:"$sample_name"
 
 #
 # Upload results
 #
 #mark-section "uploading results"
+
 mkdir -p ~/out/report_html/ ~/out/stats_txt/
 mv results/*/fastqc_report.html ~/out/report_html/"$reads_prefix".stats-fastqc.html
 mv results/*/fastqc_data.txt ~/out/stats_txt/"$reads_prefix".stats-fastqc.txt
@@ -99,12 +62,32 @@ main() {
     set -e -x -o pipefail
     echo "Value of fastqs: '${fastqs[@]}'"
 
+    #
+    # Set up some options
+    #
+    opts=()
+    if [[ "${contaminants_txt}" != "" ]]; then
+        opts+=("-c" "./in/contaminants_txt/*")
+    fi
+    if [[ "${adapters_txt}" != "" ]]; then
+        opts+=("-a" "./in/adapters_txt/*")
+    fi
+    if [[ "${limits_txt}" != "" ]]; then
+        opts+=("-l" "./in/limits_txt/*")
+    fi
+    if [[ "${nogroup}" == "true" ]]; then
+        opts+=("--nogroup")
+    fi
+
+    opts_str=$(echo ${opts[@]})
+    echo $opts_str
+
     # Run fastqc for each fastq input file
     fastqc_jobs=()
     for i in ${!fastqs[@]}
     do
         file_id=$(echo ${fastqs[$i]} | jq '.["$dnanexus_link"]' | sed s/\"//g )
-        command="dx-jobutil-new-job fastqc -ireads=${file_id}"
+        command="dx-jobutil-new-job fastqc -ireads=${file_id} -ikmer_size=${kmer_size} -iopts="${opts_str}" -iextra_options=${extra_options}"
         fastqc_jobs+=($(eval $command))
     done
 


### PR DESCRIPTION
Added more optional inputs
Removed grouping of bases in reads >50bp by default (i.e. each position is now one row in output)
Only accepts fastqs as inputs (might enable others in a future release later if necessary)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_fastqc/2)
<!-- Reviewable:end -->
